### PR TITLE
QOL: Updates Error Messages when utilizing Google Sheet APIs

### DIFF
--- a/functions/googleapi.ts
+++ b/functions/googleapi.ts
@@ -70,7 +70,7 @@ async function handlePostRequests(data: PostDataParams) {
 }
 
 async function handleGetRequests(data: GetDataParams) {
-  await createSheetIfRequired()
+  const newSheetCreated = await createSheetIfRequired()
   switch (data.function) {
     case 'fields':
       return getFields()
@@ -92,6 +92,8 @@ async function handleGetRequests(data: GetDataParams) {
       var groupId = rows.filter((row) => row[0] == data.area)[0][1]
       return groupId
     case 'generate':
+      if (newSheetCreated) return 'generated'
+
       var pastSheetData = (
         await getData(PAST_SHEET_DATA_RANGE, GSHEET_ID, CONFIG_SHEET)
       )[0]

--- a/functions/lib/gsheet-interface.ts
+++ b/functions/lib/gsheet-interface.ts
@@ -217,15 +217,15 @@ export async function doBatchReq(
         if (error) {
           if (error.message.search('already exists') != -1) {
             console.log('Add Sheet API Name Overlap')
-            rej('Exists')
+            rej("Sheet Name Overlap Error: The sheet you're trying to create already exists. Try incrementing the counter in the config sheet and running the script again.")
           } else if (
             error.message.search('The caller does not have permission') != -1
           ) {
             console.log('GSheet Permission Error')
-            rej('Permissions')
+            rej('Permissions Error. The server is missing the required permissions to update this GSheet via the GSheet API.')
           } else {
             console.log('The add sheet API returned an error: ' + error)
-            rej(error)
+            rej(`GSheet Raw API Error: ${error}`)
           }
           return
         } else {


### PR DESCRIPTION
If a sheet creation is manually triggered via the button in the Google Sheet, we display the server returned error response in as a pop-up. This PR updates the error returned by the Netlify server to be more descriptive.

There's also an edge-case bug where if a new sheet is due, clicking the "Generate" button duplicates the sheet twice.